### PR TITLE
Ignore `startup.lua`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@
 !.gitignore
 !.vscode
 
+startup.lua
+
 /code/lexers/


### PR DESCRIPTION
Why? Because the entire repository is basically a ComputerCraft root directory, that's why...

I wish ComputerCraft had a better way of dealing with libraries...