### PR TITLE
Made a grayscale version of vscode.lua

### DIFF
--- a/code/highlighter/vscode-gray.lua
+++ b/code/highlighter/vscode-gray.lua
@@ -1,0 +1,16 @@
+return {
+  comment = { colors.gray },
+  identifier = { colors.white },
+  invalid = { colors.white },
+  keyword = {
+    flow = colors.lightGray,
+    operator = colors.white,
+    value = colors.lightGray,
+  },
+  number = { colors.white },
+  operator = { colors.lightGray },
+  string = {
+    colors.white,
+    escape = colors.white,
+  },
+}


### PR DESCRIPTION
Made a grayscale version of vscode.lua,
to begin resolving issue #13 however i want to resolve PR #22 first because i would like to
implement a check via `term.isColor()` in the installer to decide if the grayscale version or color version should be installed.